### PR TITLE
Reverse sorting order of projects

### DIFF
--- a/_data/abnd.yml
+++ b/_data/abnd.yml
@@ -26,7 +26,7 @@
 #       icon: github
 #       url: https://github.com/myname/myapp
 #      
-# v- Add new projects below this line -v
+# v- Add new projects to the end of the file
 - name: Stockholm Tour Guide
   banner: https://i.imgur.com/j9LbQv7.png
   links:

--- a/_data/abnd.yml
+++ b/_data/abnd.yml
@@ -27,27 +27,6 @@
 #       url: https://github.com/myname/myapp
 #      
 # v- Add new projects to the end of the file
-- name: Stockholm Tour Guide
-  banner: https://i.imgur.com/j9LbQv7.png
-  links:
-    - title: Github
-      icon: github
-      url: https://github.com/leahZhangleah/STOCKHOLMTOURGUIDE
-  description: |
-    Stockholm Tour Guide app gives brief introduction of this city and provides information about tours, hotels
-    and restaurant recommendations.
-    
-  author: Qiongshu Zhang
-  author_links:
-    - title: GitHub
-      icon: github
-      url: https://github.com/leahZhangleah
-    - title: LinkedIn
-      icon: linkedin
-      url: https://www.linkedin.com/in/qiongshu-leah-zhang-b4362b61/
-
-  author_location: Stockholm, Sweden
-  
 - name: NewsReader
   banner: https://i.imgur.com/OV8xQfZ.jpg
   links:
@@ -92,6 +71,27 @@
 
   author_location: Mont-de-Marsan, France
   author_avatar: https://i.imgur.com/BhtwOK4.jpg
+
+- name: Stockholm Tour Guide
+  banner: https://i.imgur.com/j9LbQv7.png
+  links:
+    - title: Github
+      icon: github
+      url: https://github.com/leahZhangleah/STOCKHOLMTOURGUIDE
+  description: |
+    Stockholm Tour Guide app gives brief introduction of this city and provides information about tours, hotels
+    and restaurant recommendations.
+    
+  author: Qiongshu Zhang
+  author_links:
+    - title: GitHub
+      icon: github
+      url: https://github.com/leahZhangleah
+    - title: LinkedIn
+      icon: linkedin
+      url: https://www.linkedin.com/in/qiongshu-leah-zhang-b4362b61/
+
+  author_location: Stockholm, Sweden
 
 - name: Avengers Score Keeper App 
   banner: https://i.imgur.com/RC9WHXR.jpg

--- a/_data/and.yml
+++ b/_data/and.yml
@@ -26,7 +26,7 @@
 #       icon: github
 #       url: https://github.com/myname/myapp
 #      
-# v- Add new projects below this line -v
+# v- Add new projects to the end of the file
 
 - name: WatchNext
   banner: https://i.imgur.com/tmJ5IeN.png

--- a/_data/and.yml
+++ b/_data/and.yml
@@ -28,34 +28,6 @@
 #      
 # v- Add new projects to the end of the file
 
-- name: WatchNext
-  banner: https://i.imgur.com/tmJ5IeN.png
-  links:
-    - title: Play Store
-      icon: playstore
-      url: https://play.google.com/store/apps/details?id=com.lineargs.watchnext
-    - title: Instagram
-      icon: instagram
-      url: https://www.instagram.com/watchnextapp/
-    - title: Website
-      icon: web
-      url: https://lineargs.github.io/WatchNextApp/
-    - title: Github
-      icon: github
-      url: https://github.com/lineargs/WatchNextApp
-  description: |
-    Simple application to track and explore all the information from your favourite movies and series.
-  author: Goran Minov
-  author_location: London, United Kingdom
-  author_avatar: https://i.imgur.com/C7kV57v.jpg
-  author_links:
-    - title: LinkedIn
-      icon: linkedin
-      url: https://www.linkedin.com/in/lineargs/
-    - title: GitHub
-      icon: github
-      url: https://github.com/lineargs
-      
 - name: BookInHand
   banner: https://i.imgur.com/Rk5GVoU.png
   links:
@@ -130,6 +102,34 @@
     - title: GitHub
       icon: github
       url: https://github.com/yogourt
+      
+- name: WatchNext
+  banner: https://i.imgur.com/tmJ5IeN.png
+  links:
+    - title: Play Store
+      icon: playstore
+      url: https://play.google.com/store/apps/details?id=com.lineargs.watchnext
+    - title: Instagram
+      icon: instagram
+      url: https://www.instagram.com/watchnextapp/
+    - title: Website
+      icon: web
+      url: https://lineargs.github.io/WatchNextApp/
+    - title: Github
+      icon: github
+      url: https://github.com/lineargs/WatchNextApp
+  description: |
+    Simple application to track and explore all the information from your favourite movies and series.
+  author: Goran Minov
+  author_location: London, United Kingdom
+  author_avatar: https://i.imgur.com/C7kV57v.jpg
+  author_links:
+    - title: LinkedIn
+      icon: linkedin
+      url: https://www.linkedin.com/in/lineargs/
+    - title: GitHub
+      icon: github
+      url: https://github.com/lineargs
       
 - name: Radical News
   banner: https://i.imgur.com/DQzSfor.jpg

--- a/_data/fend.yml
+++ b/_data/fend.yml
@@ -28,55 +28,6 @@
 #
 # v- Add new projects to the end of the file
 
-- name: Asian Restaurants in Warsaw
-  banner: https://i.imgur.com/BdJYkHp.png
-  links:
-    - title: Live Page
-      icon: web
-      url: https://klaraborowska.github.io/asian-restaurants-map/
-    - title: Github Repo
-      icon: github
-      url: https://github.com/klaraborowska/asian-restaurants-map
-  description: |
-      A single page application featuring a map showing locations of Asian Restaurants in Warsaw. 
-      It's possible to filter restaurant's by category or name. 
-      Clicking on marker or on restaurant's name will open a window with information about the venue.
-  author: Klara Borowska
-  author_avatar: https://i.imgur.com/9e193lo.jpg
-  author_location: Warsaw, Poland
-  author_links:
-    - title: LinkedIn
-      icon: linkedin
-      url: https://www.linkedin.com/in/klara-borowska/
-    - title: Github Profile
-      icon: github
-      url: https://github.com/klaraborowska
-
-- name: Dublin Train Information
-  banner: https://i.imgur.com/4wMD51s.jpg
-  links:
-    - title: Live Page
-      icon: web
-      url: https://rodcunha.github.io/DART_app/
-    - title: Github Repo
-      icon: github
-      url: https://github.com/rodcunha/DART_app
-  description: |
-    Initially this started as only a location for all the suburban train stations
-    in Dublin but I've decided to expand it and I am now integrating other areas of interest
-    as well as timetables for the trains. Still a work in progress.
-    
-  author: Rodrigo Cunha
-  author_avatar: https://i.imgur.com/CV2O3yG.jpg
-  author_location: Dublin, Ireland
-  author_links:
-    - title: LinkedIn
-      icon: linkedin
-      url: https://www.linkedin.com/in/rodrigo-da-cunha/
-    - title: Github Profile
-      icon: github
-      url: https://github.com/rodcunha
-
 - name: Gwent Memory Game
   banner: https://i.imgur.com/wUOfliR.jpg
   links:
@@ -219,3 +170,53 @@
     - title: Twitter Profile
       icon: twitter
       url: https://twitter.com/bycorsanchez
+
+- name: Dublin Train Information
+  banner: https://i.imgur.com/4wMD51s.jpg
+  links:
+    - title: Live Page
+      icon: web
+      url: https://rodcunha.github.io/DART_app/
+    - title: Github Repo
+      icon: github
+      url: https://github.com/rodcunha/DART_app
+  description: |
+    Initially this started as only a location for all the suburban train stations
+    in Dublin but I've decided to expand it and I am now integrating other areas of interest
+    as well as timetables for the trains. Still a work in progress.
+    
+  author: Rodrigo Cunha
+  author_avatar: https://i.imgur.com/CV2O3yG.jpg
+  author_location: Dublin, Ireland
+  author_links:
+    - title: LinkedIn
+      icon: linkedin
+      url: https://www.linkedin.com/in/rodrigo-da-cunha/
+    - title: Github Profile
+      icon: github
+      url: https://github.com/rodcunha
+
+- name: Asian Restaurants in Warsaw
+  banner: https://i.imgur.com/BdJYkHp.png
+  links:
+    - title: Live Page
+      icon: web
+      url: https://klaraborowska.github.io/asian-restaurants-map/
+    - title: Github Repo
+      icon: github
+      url: https://github.com/klaraborowska/asian-restaurants-map
+  description: |
+      A single page application featuring a map showing locations of Asian Restaurants in Warsaw. 
+      It's possible to filter restaurant's by category or name. 
+      Clicking on marker or on restaurant's name will open a window with information about the venue.
+  author: Klara Borowska
+  author_avatar: https://i.imgur.com/9e193lo.jpg
+  author_location: Warsaw, Poland
+  author_links:
+    - title: LinkedIn
+      icon: linkedin
+      url: https://www.linkedin.com/in/klara-borowska/
+    - title: Github Profile
+      icon: github
+      url: https://github.com/klaraborowska
+

--- a/_data/fend.yml
+++ b/_data/fend.yml
@@ -26,7 +26,7 @@
 #       icon: github
 #       url: https://github.com/myname/myapp
 #
-# v- Add new projects below this line -v
+# v- Add new projects to the end of the file
 
 - name: Asian Restaurants in Warsaw
   banner: https://i.imgur.com/BdJYkHp.png

--- a/_data/mws.yml
+++ b/_data/mws.yml
@@ -26,7 +26,7 @@
 #       icon: github
 #       url: https://github.com/myname/myapp
 #      
-# v- Add new projects below this line -v
+# v- Add new projects to the end of the file
 - name: RestaurantApp
   banner: https://i.imgur.com/bn9FGwG.png
   links:

--- a/_data/mws.yml
+++ b/_data/mws.yml
@@ -27,31 +27,6 @@
 #       url: https://github.com/myname/myapp
 #      
 # v- Add new projects to the end of the file
-- name: RestaurantApp
-  banner: https://i.imgur.com/bn9FGwG.png
-  links:
-    - title: Github
-      icon: github
-      url: https://github.com/rozzilla/mws-restaurant-stage-3
-  description: |
-    Read informations about restaurants, add them to your favourites, write and read reviews.
-    And do it offline at all (thanks to the Service Worker and IndexedDb)!
-    
-  author: Roberto Bianchi
-  author_links:
-    - title: GitHub
-      icon: github
-      url: https://github.com/rozzilla
-    - title: LinkedIn
-      icon: linkedin
-      url: https://www.linkedin.com/in/robertobianchiweb/
-    - title: Twitter
-      icon: twitter
-      url: https://twitter.com/robertobianki
-
-  author_location: Imperia, Italy
-  author_avatar: https://avatars1.githubusercontent.com/u/3996291?s=460&v=4
-
 
 - name: RestaurantApp
   banner: https://i.imgur.com/0nVHgZF.png
@@ -79,6 +54,30 @@
   author_location: London, England
   author_avatar: https://avatars3.githubusercontent.com/u/16916098
   
+- name: RestaurantApp
+  banner: https://i.imgur.com/bn9FGwG.png
+  links:
+    - title: Github
+      icon: github
+      url: https://github.com/rozzilla/mws-restaurant-stage-3
+  description: |
+    Read informations about restaurants, add them to your favourites, write and read reviews.
+    And do it offline at all (thanks to the Service Worker and IndexedDb)!
+    
+  author: Roberto Bianchi
+  author_links:
+    - title: GitHub
+      icon: github
+      url: https://github.com/rozzilla
+    - title: LinkedIn
+      icon: linkedin
+      url: https://www.linkedin.com/in/robertobianchiweb/
+    - title: Twitter
+      icon: twitter
+      url: https://twitter.com/robertobianki
+
+  author_location: Imperia, Italy
+  author_avatar: https://avatars1.githubusercontent.com/u/3996291?s=460&v=4
   
 - name: RestaurantApp
   banner: https://i.imgur.com/K1xTmqD.png

--- a/_includes/works-grid.html
+++ b/_includes/works-grid.html
@@ -1,5 +1,5 @@
 <div class="mdl-grid">
-  {% for work in include.works %}
+  {% for work in include.works reversed %}
   <div class="mdl-card mdl-shadow--2dp mdl-cell mdl-cell--4-col mdl-cell--4-col-desktop mdl-cell--4-col-tablet  mdl-cell--12-col-phone">
     <a style="color: inherit; text-decoration:none;" href="{{ work.links[0].url }}">
       <div class="mdl-card__title" {% if work.banner %} style="background: url('{{ work.banner }}') center/cover;" {% endif %}>


### PR DESCRIPTION
It was the idea that the newer projects would appear at the top.

Turns out that people are more inclined to add their projects at the bottom of the list.

To follow up on the original idea, the sorting order of entries was reversed.

Existing projects were sorted in the order of their submission.